### PR TITLE
Remove canImport(CoreMotion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         xcode:
           - 12.5
-          - 13.0
+          - '13.0'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   tests:
-    runs-on: macOS-10.15
+    runs-on: macOS-11.0
     strategy:
       matrix:
         xcode:
-          - 12.4
+          - 12.5
+          - 13.0
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/ComposableCoreMotion.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableCoreMotion.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "ff42ec9061d864de7982162011321d3df5080c10",
-          "version": "0.1.2"
+          "revision": "6bde3b0063ba8e7537b43744948535ca7e9e0dad",
+          "version": "0.5.2"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "ed1838ab4fa5d47db8aa640736dd5b7672548873",
-          "version": "0.1.2"
+          "revision": "d226d167bd4a68b51e352af5655c92bce8ee0463",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "9d8719c8bebdc79740b6969c912ac706eb721d7a",
+          "version": "0.0.7"
         }
       },
       {
@@ -24,8 +33,35 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture",
         "state": {
           "branch": null,
-          "revision": "b67569f69813140cd9c984db33ee959d9711a008",
-          "version": "0.9.0"
+          "revision": "68664c144e0d49d2fff1f45081f1bb57203b88fd",
+          "version": "0.25.1"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "8655495733d8c712db8d9078f47d17f3555db79f",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "package": "swift-identified-collections",
+        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
+        "state": {
+          "branch": null,
+          "revision": "04502c882077cd838d380d05b127db9a6e48d8da",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
         }
       }
     ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PLATFORM_IOS = iOS Simulator,name=iPhone 11 Pro Max
 PLATFORM_MACOS = macOS
-PLATFORM_TVOS = tvOS Simulator,name=Apple TV 4K (at 1080p)
 PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 4 - 44mm
 
 default: test
@@ -12,9 +11,6 @@ test:
 	xcodebuild test \
 		-scheme ComposableCoreMotion \
 		-destination platform="$(PLATFORM_MACOS)"
-	xcodebuild test \
-		-scheme ComposableCoreMotion \
-		-destination platform="$(PLATFORM_TVOS)"
 	xcodebuild \
 		-scheme ComposableCoreMotion_watchOS \
 		-destination platform="$(PLATFORM_WATCHOS)"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -7,7 +7,6 @@ let package = Package(
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),
-    .tvOS(.v13),
     .watchOS(.v6),
   ],
   products: [
@@ -17,7 +16,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.9.0")
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.21.0")
   ],
   targets: [
     .target(

--- a/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerInterface.swift
+++ b/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerInterface.swift
@@ -1,98 +1,96 @@
-#if canImport(CoreMotion)
-  import ComposableArchitecture
-  import CoreMotion
+import ComposableArchitecture
+import CoreMotion
 
-  /// A wrapper around Core Motion's `CMHeadphoneMotionManager` that exposes its functionality
-  /// through effects and actions, making it easy to use with the Composable Architecture, and easy
-  /// to test.
-  @available(iOS 14, *)
-  @available(macCatalyst 14, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS 7, *)
-  public struct HeadphoneMotionManager {
+/// A wrapper around Core Motion's `CMHeadphoneMotionManager` that exposes its functionality
+/// through effects and actions, making it easy to use with the Composable Architecture, and easy
+/// to test.
+@available(iOS 14, *)
+@available(macCatalyst 14, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS 7, *)
+public struct HeadphoneMotionManager {
 
-    /// Actions that correspond to `CMHeadphoneMotionManagerDelegate` methods.
-    ///
-    /// See `CMHeadphoneMotionManagerDelegate` for more information.
-    public enum Action: Equatable {
-      case didConnect
-      case didDisconnect
-    }
-
-    /// Creates a headphone motion manager.
-    ///
-    /// A motion manager must be first created before you can use its functionality, such as
-    /// starting device motion updates or accessing data directly from the manager.
-    public func create(id: AnyHashable) -> Effect<Action, Never> {
-      self.create(id)
-    }
-
-    /// Destroys a currently running headphone motion manager.
-    ///
-    /// In is good practice to destroy a headphone motion manager once you are done with it, such as
-    /// when you leave a screen or no longer need motion data.
-    public func destroy(id: AnyHashable) -> Effect<Never, Never> {
-      self.destroy(id)
-    }
-
-    /// The latest sample of device-motion data.
-    public func deviceMotion(id: AnyHashable) -> DeviceMotion? {
-      self.deviceMotion(id)
-    }
-
-    /// A Boolean value that determines whether the app is receiving updates from the device-motion
-    /// service.
-    public func isDeviceMotionActive(id: AnyHashable) -> Bool {
-      self.isDeviceMotionActive(id)
-    }
-
-    /// A Boolean value that indicates whether the device-motion service is available on the device.
-    public func isDeviceMotionAvailable(id: AnyHashable) -> Bool {
-      self.isDeviceMotionAvailable(id)
-    }
-
-    /// Starts device-motion updates without a block handler.
-    ///
-    /// Returns a long-living effect that emits device motion data each time the headphone motion
-    /// manager receives a new value.
-    public func startDeviceMotionUpdates(
-      id: AnyHashable,
-      to queue: OperationQueue = .main
-    ) -> Effect<DeviceMotion, Error> {
-      self.startDeviceMotionUpdates(id, queue)
-    }
-
-    /// Stops device-motion updates.
-    public func stopDeviceMotionUpdates(id: AnyHashable) -> Effect<Never, Never> {
-      self.stopDeviceMotionUpdates(id)
-    }
-
-    public init(
-      create: @escaping (AnyHashable) -> Effect<Action, Never>,
-      destroy: @escaping (AnyHashable) -> Effect<Never, Never>,
-      deviceMotion: @escaping (AnyHashable) -> DeviceMotion?,
-      isDeviceMotionActive: @escaping (AnyHashable) -> Bool,
-      isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool,
-      startDeviceMotionUpdates: @escaping (AnyHashable, OperationQueue) ->
-        Effect<DeviceMotion, Error>,
-      stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never>
-    ) {
-      self.create = create
-      self.destroy = destroy
-      self.deviceMotion = deviceMotion
-      self.isDeviceMotionActive = isDeviceMotionActive
-      self.isDeviceMotionAvailable = isDeviceMotionAvailable
-      self.startDeviceMotionUpdates = startDeviceMotionUpdates
-      self.stopDeviceMotionUpdates = stopDeviceMotionUpdates
-    }
-
-    var create: (AnyHashable) -> Effect<Action, Never>
-    var destroy: (AnyHashable) -> Effect<Never, Never>
-    var deviceMotion: (AnyHashable) -> DeviceMotion?
-    var isDeviceMotionActive: (AnyHashable) -> Bool
-    var isDeviceMotionAvailable: (AnyHashable) -> Bool
-    var startDeviceMotionUpdates: (AnyHashable, OperationQueue) -> Effect<DeviceMotion, Error>
-    var stopDeviceMotionUpdates: (AnyHashable) -> Effect<Never, Never>
+  /// Actions that correspond to `CMHeadphoneMotionManagerDelegate` methods.
+  ///
+  /// See `CMHeadphoneMotionManagerDelegate` for more information.
+  public enum Action: Equatable {
+    case didConnect
+    case didDisconnect
   }
-#endif
+
+  /// Creates a headphone motion manager.
+  ///
+  /// A motion manager must be first created before you can use its functionality, such as
+  /// starting device motion updates or accessing data directly from the manager.
+  public func create(id: AnyHashable) -> Effect<Action, Never> {
+    self.create(id)
+  }
+
+  /// Destroys a currently running headphone motion manager.
+  ///
+  /// In is good practice to destroy a headphone motion manager once you are done with it, such as
+  /// when you leave a screen or no longer need motion data.
+  public func destroy(id: AnyHashable) -> Effect<Never, Never> {
+    self.destroy(id)
+  }
+
+  /// The latest sample of device-motion data.
+  public func deviceMotion(id: AnyHashable) -> DeviceMotion? {
+    self.deviceMotion(id)
+  }
+
+  /// A Boolean value that determines whether the app is receiving updates from the device-motion
+  /// service.
+  public func isDeviceMotionActive(id: AnyHashable) -> Bool {
+    self.isDeviceMotionActive(id)
+  }
+
+  /// A Boolean value that indicates whether the device-motion service is available on the device.
+  public func isDeviceMotionAvailable(id: AnyHashable) -> Bool {
+    self.isDeviceMotionAvailable(id)
+  }
+
+  /// Starts device-motion updates without a block handler.
+  ///
+  /// Returns a long-living effect that emits device motion data each time the headphone motion
+  /// manager receives a new value.
+  public func startDeviceMotionUpdates(
+    id: AnyHashable,
+    to queue: OperationQueue = .main
+  ) -> Effect<DeviceMotion, Error> {
+    self.startDeviceMotionUpdates(id, queue)
+  }
+
+  /// Stops device-motion updates.
+  public func stopDeviceMotionUpdates(id: AnyHashable) -> Effect<Never, Never> {
+    self.stopDeviceMotionUpdates(id)
+  }
+
+  public init(
+    create: @escaping (AnyHashable) -> Effect<Action, Never>,
+    destroy: @escaping (AnyHashable) -> Effect<Never, Never>,
+    deviceMotion: @escaping (AnyHashable) -> DeviceMotion?,
+    isDeviceMotionActive: @escaping (AnyHashable) -> Bool,
+    isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool,
+    startDeviceMotionUpdates: @escaping (AnyHashable, OperationQueue) ->
+      Effect<DeviceMotion, Error>,
+    stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never>
+  ) {
+    self.create = create
+    self.destroy = destroy
+    self.deviceMotion = deviceMotion
+    self.isDeviceMotionActive = isDeviceMotionActive
+    self.isDeviceMotionAvailable = isDeviceMotionAvailable
+    self.startDeviceMotionUpdates = startDeviceMotionUpdates
+    self.stopDeviceMotionUpdates = stopDeviceMotionUpdates
+  }
+
+  var create: (AnyHashable) -> Effect<Action, Never>
+  var destroy: (AnyHashable) -> Effect<Never, Never>
+  var deviceMotion: (AnyHashable) -> DeviceMotion?
+  var isDeviceMotionActive: (AnyHashable) -> Bool
+  var isDeviceMotionAvailable: (AnyHashable) -> Bool
+  var startDeviceMotionUpdates: (AnyHashable, OperationQueue) -> Effect<DeviceMotion, Error>
+  var stopDeviceMotionUpdates: (AnyHashable) -> Effect<Never, Never>
+}

--- a/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerLive.swift
+++ b/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerLive.swift
@@ -1,4 +1,4 @@
-#if canImport(CoreMotion) && compiler(>=5.3) && (os(iOS) || os(watchOS) || targetEnvironment(macCatalyst))
+#if compiler(>=5.3) && (os(iOS) || os(watchOS) || targetEnvironment(macCatalyst))
   import Combine
   import ComposableArchitecture
   import CoreMotion

--- a/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerMock.swift
+++ b/Sources/ComposableCoreMotion/HeadphoneMotionManager/HeadphoneMotionManagerMock.swift
@@ -1,38 +1,36 @@
-#if canImport(CoreMotion)
-  import ComposableArchitecture
+import ComposableArchitecture
 
-  @available(iOS 14, *)
-  @available(macCatalyst 14, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS 7, *)
-  extension HeadphoneMotionManager {
-    public static func unimplemented(
-      create: @escaping (AnyHashable) -> Effect<Action, Never> = { _ in _unimplemented("create") },
-      destroy: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("destroy") },
-      deviceMotion: @escaping (AnyHashable) -> DeviceMotion? = { _ in _unimplemented("deviceMotion")
-      },
-      isDeviceMotionActive: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isDeviceMotionActive")
-      },
-      isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isDeviceMotionAvailable")
-      },
-      startDeviceMotionUpdates: @escaping (AnyHashable, OperationQueue) ->
-        Effect<DeviceMotion, Error> = { _, _ in _unimplemented("startDeviceMotionUpdates") },
-      stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
-        _unimplemented("stopDeviceMotionUpdates")
-      }
-    ) -> HeadphoneMotionManager {
-      Self(
-        create: create,
-        destroy: destroy,
-        deviceMotion: deviceMotion,
-        isDeviceMotionActive: isDeviceMotionActive,
-        isDeviceMotionAvailable: isDeviceMotionAvailable,
-        startDeviceMotionUpdates: startDeviceMotionUpdates,
-        stopDeviceMotionUpdates: stopDeviceMotionUpdates
-      )
+@available(iOS 14, *)
+@available(macCatalyst 14, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS 7, *)
+extension HeadphoneMotionManager {
+  public static func unimplemented(
+    create: @escaping (AnyHashable) -> Effect<Action, Never> = { _ in _unimplemented("create") },
+    destroy: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("destroy") },
+    deviceMotion: @escaping (AnyHashable) -> DeviceMotion? = { _ in _unimplemented("deviceMotion")
+    },
+    isDeviceMotionActive: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isDeviceMotionActive")
+    },
+    isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isDeviceMotionAvailable")
+    },
+    startDeviceMotionUpdates: @escaping (AnyHashable, OperationQueue) ->
+      Effect<DeviceMotion, Error> = { _, _ in _unimplemented("startDeviceMotionUpdates") },
+    stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      _unimplemented("stopDeviceMotionUpdates")
     }
+  ) -> HeadphoneMotionManager {
+    Self(
+      create: create,
+      destroy: destroy,
+      deviceMotion: deviceMotion,
+      isDeviceMotionActive: isDeviceMotionActive,
+      isDeviceMotionAvailable: isDeviceMotionAvailable,
+      startDeviceMotionUpdates: startDeviceMotionUpdates,
+      stopDeviceMotionUpdates: stopDeviceMotionUpdates
+    )
   }
-#endif
+}

--- a/Sources/ComposableCoreMotion/Internal/Exports.swift
+++ b/Sources/ComposableCoreMotion/Internal/Exports.swift
@@ -1,4 +1,2 @@
-#if canImport(CoreMotion)
-  @_exported import ComposableArchitecture
-  @_exported import CoreMotion
-#endif
+@_exported import ComposableArchitecture
+@_exported import CoreMotion

--- a/Sources/ComposableCoreMotion/MotionManager/MotionManagerInterface.swift
+++ b/Sources/ComposableCoreMotion/MotionManager/MotionManagerInterface.swift
@@ -1,454 +1,452 @@
-#if canImport(CoreMotion)
-  import ComposableArchitecture
-  import CoreMotion
+import ComposableArchitecture
+import CoreMotion
 
-  /// A wrapper around Core Motion's `CMMotionManager` that exposes its functionality through
-  /// effects and actions, making it easy to use with the Composable Architecture, and easy to test.
-  ///
-  /// To use in your application, you can add an action to your feature's domain that represents the
-  /// type of motion data you are interested in receiving. For example, if you only want motion
-  /// updates, then you can add the following action:
-  ///
-  ///     import ComposableCoreLocation
-  ///
-  ///     enum FeatureAction {
-  ///       case motionUpdate(Result<DeviceMotion, NSError>)
-  ///
-  ///       // Your feature's other actions:
-  ///       ...
-  ///     }
-  ///
-  /// This action will be sent every time the motion manager receives new device motion data.
-  ///
-  /// Next, add a `MotionManager` type, which is a wrapper around a `CMMotionManager` that this
-  /// library provides, to your feature's environment of dependencies:
-  ///
-  ///     struct FeatureEnvironment {
-  ///       var motionManager: MotionManager
-  ///
-  ///       // Your feature's other dependencies:
-  ///       ...
-  ///     }
-  ///
-  /// Then, create a motion manager by returning an effect from our reducer. You can either do this
-  /// when your feature starts up, such as when `onAppear` is invoked, or you can do it when a user
-  /// action occurs, such as when the user taps a button.
-  ///
-  /// As an example, say we want to create a motion manager and start listening for motion updates
-  /// when a "Record" button is tapped. Then we can can do both of those things by executing two
-  /// effects, one after the other:
-  ///
-  ///     let featureReducer = Reducer<FeatureState, FeatureAction, FeatureEnvironment> {
-  ///       state, action, environment in
-  ///
-  ///       // A unique identifier for our location manager, just in case we want to use
-  ///       // more than one in our application.
-  ///       struct MotionManagerId: Hashable {}
-  ///
-  ///       switch action {
-  ///       case .recordingButtonTapped:
-  ///         return .concatenate(
-  ///           environment.motionManager
-  ///             .create(id: MotionManagerId())
-  ///             .fireAndForget(),
-  ///
-  ///           environment.motionManager
-  ///             .startDeviceMotionUpdates(
-  ///               id: MotionManagerId(),
-  ///               using: .xArbitraryZVertical,
-  ///               to: .main
-  ///             )
-  ///             .mapError { $0 as NSError }
-  ///             .catchToEffect()
-  ///             .map(AppAction.motionUpdate)
-  ///         )
-  ///
-  ///       ...
-  ///       }
-  ///     }
-  ///
-  /// After those effects are executed you will get a steady stream of device motion updates sent to
-  /// the `.motionUpdate` action, which you can handle in the reducer. For example, to compute how
-  /// much the device is moving up and down we can take the dot product of the device's gravity
-  /// vector with the device's acceleration vector, and we could store that in the feature's state:
-  ///
-  ///     case let .motionUpdate(.success(deviceMotion)):
-  ///        state.zs.append(
-  ///          motion.gravity.x * motion.userAcceleration.x
-  ///            + motion.gravity.y * motion.userAcceleration.y
-  ///            + motion.gravity.z * motion.userAcceleration.z
-  ///        )
-  ///
-  ///     case let .motionUpdate(.failure(error)):
-  ///       // Do something with the motion update failure, like show an alert.
-  ///
-  /// And then later, if you want to stop receiving motion updates, such as when a "Stop" button is
-  /// tapped, we can execute an effect to stop the motion manager, and even fully destroy it if we
-  /// don't need the manager anymore:
-  ///
-  ///     case .stopButtonTapped:
-  ///       return .concatenate(
-  ///         environment.motionManager
-  ///           .stopDeviceMotionUpdates(id: MotionManagerId())
-  ///           .fireAndForget(),
-  ///
-  ///         environment.motionManager
-  ///           .destroy(id: MotionManagerId())
-  ///           .fireAndForget()
-  ///       )
-  ///
-  /// That is enough to implement a basic application that interacts with Core Motion.
-  ///
-  /// But the true power of building your application and interfacing with Core Motion this way is
-  /// the ability to instantly _test_ how your application behaves with Core Motion. We start by
-  /// creating a `TestStore` whose environment contains an `.unimplemented` version of the
-  /// `MotionManager`. The `.unimplemented` function allows you to create a fully controlled version
-  /// of the motion manager that does not deal with a real `CMMotionManager` at all. Instead, you
-  /// override whichever endpoints your feature needs to supply deterministic functionality.
-  ///
-  /// For example, let's test that we property start the motion manager when we tap the record
-  /// button, and that we compute the z-motion correctly, and further that we stop the motion
-  /// manager when we tap the stop button. We can construct a `TestStore` with a mock motion manager
-  /// that keeps track of when the manager is created and destroyed, and further we can even
-  /// substitute in a subject that we control for device motion updates. This allows us to send any
-  /// data we want to for the device motion.
-  ///
-  ///     func testFeature() {
-  ///       let motionSubject = PassthroughSubject<DeviceMotion, Error>()
-  ///       var motionManagerIsLive = false
-  ///
-  ///       let store = TestStore(
-  ///         initialState: .init(),
-  ///         reducer: appReducer,
-  ///         environment: .init(
-  ///           motionManager: .unimplemented(
-  ///             create: { _ in .fireAndForget { motionManagerIsLive = true } },
-  ///             destroy: { _ in .fireAndForget { motionManagerIsLive = false } },
-  ///             startDeviceMotionUpdates: { _, _, _ in motionSubject.eraseToEffect() },
-  ///             stopDeviceMotionUpdates: { _ in
-  ///               .fireAndForget { motionSubject.send(completion: .finished) }
-  ///             }
-  ///           )
-  ///         )
-  ///       )
-  ///     }
-  ///
-  /// We can then make an assertion on our store that plays a basic user script. We can simulate the
-  /// situation in which a user taps the record button, then some device motion data is received,
-  /// and finally the user taps the stop button. During that script of user actions we expect the
-  /// motion manager to be started, then for some z-motion values to be accumulated, and finally for
-  /// the motion manager to be stopped:
-  ///
-  ///     let deviceMotion = DeviceMotion(
-  ///       attitude: .init(quaternion: .init(x: 1, y: 0, z: 0, w: 0)),
-  ///       gravity: CMAcceleration(x: 1, y: 2, z: 3),
-  ///       heading: 0,
-  ///       magneticField: .init(field: .init(x: 0, y: 0, z: 0), accuracy: .high),
-  ///       rotationRate: .init(x: 0, y: 0, z: 0),
-  ///       timestamp: 0,
-  ///       userAcceleration: CMAcceleration(x: 4, y: 5, z: 6)
-  ///     )
-  ///
-  ///     store.assert(
-  ///       .send(.recordingButtonTapped) {
-  ///         XCTAssertEqual(motionManagerIsLive, true)
-  ///       },
-  ///       .do { motionSubject.send(deviceMotion) },
-  ///       .receive(.motionUpdate(.success(deviceMotion))) {
-  ///         $0.zs = [32]
-  ///       },
-  ///       .send(.stopButtonTapped) {
-  ///         XCTAssertEqual(motionManagerIsLive, false)
-  ///       }
-  ///     )
-  ///
-  /// This is only the tip of the iceberg. We can access any part of the `CMMotionManager` API in
-  /// this way, and instantly unlock testability with how the motion functionality integrates with
-  /// our core application logic. This can be incredibly powerful, and is typically not the kind of
-  /// thing one can test easily.
-  ///
-  @available(iOS 4.0, *)
-  @available(macCatalyst 13.0, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS 2.0, *)
-  public struct MotionManager {
-    /// The latest sample of accelerometer data.
-    public func accelerometerData(id: AnyHashable) -> AccelerometerData? {
-      self.accelerometerData(id)
-    }
+/// A wrapper around Core Motion's `CMMotionManager` that exposes its functionality through
+/// effects and actions, making it easy to use with the Composable Architecture, and easy to test.
+///
+/// To use in your application, you can add an action to your feature's domain that represents the
+/// type of motion data you are interested in receiving. For example, if you only want motion
+/// updates, then you can add the following action:
+///
+///     import ComposableCoreLocation
+///
+///     enum FeatureAction {
+///       case motionUpdate(Result<DeviceMotion, NSError>)
+///
+///       // Your feature's other actions:
+///       ...
+///     }
+///
+/// This action will be sent every time the motion manager receives new device motion data.
+///
+/// Next, add a `MotionManager` type, which is a wrapper around a `CMMotionManager` that this
+/// library provides, to your feature's environment of dependencies:
+///
+///     struct FeatureEnvironment {
+///       var motionManager: MotionManager
+///
+///       // Your feature's other dependencies:
+///       ...
+///     }
+///
+/// Then, create a motion manager by returning an effect from our reducer. You can either do this
+/// when your feature starts up, such as when `onAppear` is invoked, or you can do it when a user
+/// action occurs, such as when the user taps a button.
+///
+/// As an example, say we want to create a motion manager and start listening for motion updates
+/// when a "Record" button is tapped. Then we can can do both of those things by executing two
+/// effects, one after the other:
+///
+///     let featureReducer = Reducer<FeatureState, FeatureAction, FeatureEnvironment> {
+///       state, action, environment in
+///
+///       // A unique identifier for our location manager, just in case we want to use
+///       // more than one in our application.
+///       struct MotionManagerId: Hashable {}
+///
+///       switch action {
+///       case .recordingButtonTapped:
+///         return .concatenate(
+///           environment.motionManager
+///             .create(id: MotionManagerId())
+///             .fireAndForget(),
+///
+///           environment.motionManager
+///             .startDeviceMotionUpdates(
+///               id: MotionManagerId(),
+///               using: .xArbitraryZVertical,
+///               to: .main
+///             )
+///             .mapError { $0 as NSError }
+///             .catchToEffect()
+///             .map(AppAction.motionUpdate)
+///         )
+///
+///       ...
+///       }
+///     }
+///
+/// After those effects are executed you will get a steady stream of device motion updates sent to
+/// the `.motionUpdate` action, which you can handle in the reducer. For example, to compute how
+/// much the device is moving up and down we can take the dot product of the device's gravity
+/// vector with the device's acceleration vector, and we could store that in the feature's state:
+///
+///     case let .motionUpdate(.success(deviceMotion)):
+///        state.zs.append(
+///          motion.gravity.x * motion.userAcceleration.x
+///            + motion.gravity.y * motion.userAcceleration.y
+///            + motion.gravity.z * motion.userAcceleration.z
+///        )
+///
+///     case let .motionUpdate(.failure(error)):
+///       // Do something with the motion update failure, like show an alert.
+///
+/// And then later, if you want to stop receiving motion updates, such as when a "Stop" button is
+/// tapped, we can execute an effect to stop the motion manager, and even fully destroy it if we
+/// don't need the manager anymore:
+///
+///     case .stopButtonTapped:
+///       return .concatenate(
+///         environment.motionManager
+///           .stopDeviceMotionUpdates(id: MotionManagerId())
+///           .fireAndForget(),
+///
+///         environment.motionManager
+///           .destroy(id: MotionManagerId())
+///           .fireAndForget()
+///       )
+///
+/// That is enough to implement a basic application that interacts with Core Motion.
+///
+/// But the true power of building your application and interfacing with Core Motion this way is
+/// the ability to instantly _test_ how your application behaves with Core Motion. We start by
+/// creating a `TestStore` whose environment contains an `.unimplemented` version of the
+/// `MotionManager`. The `.unimplemented` function allows you to create a fully controlled version
+/// of the motion manager that does not deal with a real `CMMotionManager` at all. Instead, you
+/// override whichever endpoints your feature needs to supply deterministic functionality.
+///
+/// For example, let's test that we property start the motion manager when we tap the record
+/// button, and that we compute the z-motion correctly, and further that we stop the motion
+/// manager when we tap the stop button. We can construct a `TestStore` with a mock motion manager
+/// that keeps track of when the manager is created and destroyed, and further we can even
+/// substitute in a subject that we control for device motion updates. This allows us to send any
+/// data we want to for the device motion.
+///
+///     func testFeature() {
+///       let motionSubject = PassthroughSubject<DeviceMotion, Error>()
+///       var motionManagerIsLive = false
+///
+///       let store = TestStore(
+///         initialState: .init(),
+///         reducer: appReducer,
+///         environment: .init(
+///           motionManager: .unimplemented(
+///             create: { _ in .fireAndForget { motionManagerIsLive = true } },
+///             destroy: { _ in .fireAndForget { motionManagerIsLive = false } },
+///             startDeviceMotionUpdates: { _, _, _ in motionSubject.eraseToEffect() },
+///             stopDeviceMotionUpdates: { _ in
+///               .fireAndForget { motionSubject.send(completion: .finished) }
+///             }
+///           )
+///         )
+///       )
+///     }
+///
+/// We can then make an assertion on our store that plays a basic user script. We can simulate the
+/// situation in which a user taps the record button, then some device motion data is received,
+/// and finally the user taps the stop button. During that script of user actions we expect the
+/// motion manager to be started, then for some z-motion values to be accumulated, and finally for
+/// the motion manager to be stopped:
+///
+///     let deviceMotion = DeviceMotion(
+///       attitude: .init(quaternion: .init(x: 1, y: 0, z: 0, w: 0)),
+///       gravity: CMAcceleration(x: 1, y: 2, z: 3),
+///       heading: 0,
+///       magneticField: .init(field: .init(x: 0, y: 0, z: 0), accuracy: .high),
+///       rotationRate: .init(x: 0, y: 0, z: 0),
+///       timestamp: 0,
+///       userAcceleration: CMAcceleration(x: 4, y: 5, z: 6)
+///     )
+///
+///     store.assert(
+///       .send(.recordingButtonTapped) {
+///         XCTAssertEqual(motionManagerIsLive, true)
+///       },
+///       .do { motionSubject.send(deviceMotion) },
+///       .receive(.motionUpdate(.success(deviceMotion))) {
+///         $0.zs = [32]
+///       },
+///       .send(.stopButtonTapped) {
+///         XCTAssertEqual(motionManagerIsLive, false)
+///       }
+///     )
+///
+/// This is only the tip of the iceberg. We can access any part of the `CMMotionManager` API in
+/// this way, and instantly unlock testability with how the motion functionality integrates with
+/// our core application logic. This can be incredibly powerful, and is typically not the kind of
+/// thing one can test easily.
+///
+@available(iOS 4.0, *)
+@available(macCatalyst 13.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS 2.0, *)
+public struct MotionManager {
+  /// The latest sample of accelerometer data.
+  public func accelerometerData(id: AnyHashable) -> AccelerometerData? {
+    self.accelerometerData(id)
+  }
 
-    /// Returns either the reference frame currently being used or the default attitude reference
-    /// frame.
-    public func attitudeReferenceFrame(id: AnyHashable) -> CMAttitudeReferenceFrame {
-      self.attitudeReferenceFrame(id)
-    }
+  /// Returns either the reference frame currently being used or the default attitude reference
+  /// frame.
+  public func attitudeReferenceFrame(id: AnyHashable) -> CMAttitudeReferenceFrame {
+    self.attitudeReferenceFrame(id)
+  }
 
-    /// Creates a motion manager.
-    ///
-    /// A motion manager must be first created before you can use its functionality, such as starting
-    /// device motion updates or accessing data directly from the manager.
-    public func create(id: AnyHashable) -> Effect<Never, Never> {
-      self.create(id)
-    }
+  /// Creates a motion manager.
+  ///
+  /// A motion manager must be first created before you can use its functionality, such as starting
+  /// device motion updates or accessing data directly from the manager.
+  public func create(id: AnyHashable) -> Effect<Never, Never> {
+    self.create(id)
+  }
 
-    /// Destroys a currently running motion manager.
-    ///
-    /// In is good practice to destroy a motion manager once you are done with it, such as when you
-    /// leave a screen or no longer need motion data.
-    public func destroy(id: AnyHashable) -> Effect<Never, Never> {
-      self.destroy(id)
-    }
+  /// Destroys a currently running motion manager.
+  ///
+  /// In is good practice to destroy a motion manager once you are done with it, such as when you
+  /// leave a screen or no longer need motion data.
+  public func destroy(id: AnyHashable) -> Effect<Never, Never> {
+    self.destroy(id)
+  }
 
-    /// The latest sample of device-motion data.
-    public func deviceMotion(id: AnyHashable) -> DeviceMotion? {
-      self.deviceMotion(id)
-    }
+  /// The latest sample of device-motion data.
+  public func deviceMotion(id: AnyHashable) -> DeviceMotion? {
+    self.deviceMotion(id)
+  }
 
-    /// The latest sample of gyroscope data.
-    public func gyroData(id: AnyHashable) -> GyroData? {
-      self.gyroData(id)
-    }
+  /// The latest sample of gyroscope data.
+  public func gyroData(id: AnyHashable) -> GyroData? {
+    self.gyroData(id)
+  }
 
-    /// A Boolean value that indicates whether accelerometer updates are currently happening.
-    public func isAccelerometerActive(id: AnyHashable) -> Bool {
-      self.isAccelerometerActive(id)
-    }
+  /// A Boolean value that indicates whether accelerometer updates are currently happening.
+  public func isAccelerometerActive(id: AnyHashable) -> Bool {
+    self.isAccelerometerActive(id)
+  }
 
-    /// A Boolean value that indicates whether an accelerometer is available on the device.
-    public func isAccelerometerAvailable(id: AnyHashable) -> Bool {
-      self.isAccelerometerAvailable(id)
-    }
+  /// A Boolean value that indicates whether an accelerometer is available on the device.
+  public func isAccelerometerAvailable(id: AnyHashable) -> Bool {
+    self.isAccelerometerAvailable(id)
+  }
 
-    /// A Boolean value that determines whether the app is receiving updates from the device-motion
-    /// service.
-    public func isDeviceMotionActive(id: AnyHashable) -> Bool {
-      self.isDeviceMotionActive(id)
-    }
+  /// A Boolean value that determines whether the app is receiving updates from the device-motion
+  /// service.
+  public func isDeviceMotionActive(id: AnyHashable) -> Bool {
+    self.isDeviceMotionActive(id)
+  }
 
-    /// A Boolean value that indicates whether the device-motion service is available on the device.
-    public func isDeviceMotionAvailable(id: AnyHashable) -> Bool {
-      self.isDeviceMotionAvailable(id)
-    }
+  /// A Boolean value that indicates whether the device-motion service is available on the device.
+  public func isDeviceMotionAvailable(id: AnyHashable) -> Bool {
+    self.isDeviceMotionAvailable(id)
+  }
 
-    /// A Boolean value that determines whether gyroscope updates are currently happening.
-    public func isGyroActive(id: AnyHashable) -> Bool {
-      self.isGyroActive(id)
-    }
+  /// A Boolean value that determines whether gyroscope updates are currently happening.
+  public func isGyroActive(id: AnyHashable) -> Bool {
+    self.isGyroActive(id)
+  }
 
-    /// A Boolean value that indicates whether a gyroscope is available on the device.
-    public func isGyroAvailable(id: AnyHashable) -> Bool {
-      self.isGyroAvailable(id)
-    }
+  /// A Boolean value that indicates whether a gyroscope is available on the device.
+  public func isGyroAvailable(id: AnyHashable) -> Bool {
+    self.isGyroAvailable(id)
+  }
 
-    /// A Boolean value that determines whether magnetometer updates are currently happening.
-    public func isMagnetometerActive(id: AnyHashable) -> Bool {
-      self.isMagnetometerActive(id)
-    }
+  /// A Boolean value that determines whether magnetometer updates are currently happening.
+  public func isMagnetometerActive(id: AnyHashable) -> Bool {
+    self.isMagnetometerActive(id)
+  }
 
-    /// A Boolean value that indicates whether a magnetometer is available on the device.
-    public func isMagnetometerAvailable(id: AnyHashable) -> Bool {
-      self.isMagnetometerAvailable(id)
-    }
+  /// A Boolean value that indicates whether a magnetometer is available on the device.
+  public func isMagnetometerAvailable(id: AnyHashable) -> Bool {
+    self.isMagnetometerAvailable(id)
+  }
 
-    /// The latest sample of magnetometer data.
-    public func magnetometerData(id: AnyHashable) -> MagnetometerData? {
-      self.magnetometerData(id)
-    }
+  /// The latest sample of magnetometer data.
+  public func magnetometerData(id: AnyHashable) -> MagnetometerData? {
+    self.magnetometerData(id)
+  }
 
-    /// Sets certain properties on the motion manager.
-    public func set(
-      id: AnyHashable,
+  /// Sets certain properties on the motion manager.
+  public func set(
+    id: AnyHashable,
+    accelerometerUpdateInterval: TimeInterval? = nil,
+    deviceMotionUpdateInterval: TimeInterval? = nil,
+    gyroUpdateInterval: TimeInterval? = nil,
+    magnetometerUpdateInterval: TimeInterval? = nil,
+    showsDeviceMovementDisplay: Bool? = nil
+  ) -> Effect<Never, Never> {
+    self.set(
+      id,
+      .init(
+        accelerometerUpdateInterval: accelerometerUpdateInterval,
+        deviceMotionUpdateInterval: deviceMotionUpdateInterval,
+        gyroUpdateInterval: gyroUpdateInterval,
+        magnetometerUpdateInterval: magnetometerUpdateInterval,
+        showsDeviceMovementDisplay: showsDeviceMovementDisplay
+      )
+    )
+  }
+
+  /// Starts accelerometer updates without a handler.
+  ///
+  /// Returns a long-living effect that emits accelerometer data each time the motion manager
+  /// receives a new value.
+  public func startAccelerometerUpdates(
+    id: AnyHashable,
+    to queue: OperationQueue = .main
+  ) -> Effect<AccelerometerData, Error> {
+    self.startAccelerometerUpdates(id, queue)
+  }
+
+  /// Starts device-motion updates without a block handler.
+  ///
+  /// Returns a long-living effect that emits device motion data each time the motion manager
+  /// receives a new value.
+  public func startDeviceMotionUpdates(
+    id: AnyHashable,
+    using referenceFrame: CMAttitudeReferenceFrame,
+    to queue: OperationQueue = .main
+  ) -> Effect<DeviceMotion, Error> {
+    self.startDeviceMotionUpdates(id, referenceFrame, queue)
+  }
+
+  /// Starts gyroscope updates without a handler.
+  ///
+  /// Returns a long-living effect that emits gyro data each time the motion manager receives a
+  /// new value.
+  public func startGyroUpdates(
+    id: AnyHashable,
+    to queue: OperationQueue = .main
+  ) -> Effect<GyroData, Error> {
+    self.startGyroUpdates(id, queue)
+  }
+
+  /// Starts magnetometer updates without a block handler.
+  ///
+  /// Returns a long-living effect that emits magnetometer data each time the motion manager
+  /// receives a new value.
+  public func startMagnetometerUpdates(
+    id: AnyHashable,
+    to queue: OperationQueue = .main
+  ) -> Effect<MagnetometerData, Error> {
+    self.startMagnetometerUpdates(id, queue)
+  }
+
+  /// Stops accelerometer updates.
+  public func stopAccelerometerUpdates(id: AnyHashable) -> Effect<Never, Never> {
+    self.stopAccelerometerUpdates(id)
+  }
+
+  /// Stops device-motion updates.
+  public func stopDeviceMotionUpdates(id: AnyHashable) -> Effect<Never, Never> {
+    self.stopDeviceMotionUpdates(id)
+  }
+
+  /// Stops gyroscope updates.
+  public func stopGyroUpdates(id: AnyHashable) -> Effect<Never, Never> {
+    self.stopGyroUpdates(id)
+  }
+
+  /// Stops magnetometer updates.
+  public func stopMagnetometerUpdates(id: AnyHashable) -> Effect<Never, Never> {
+    self.stopMagnetometerUpdates(id)
+  }
+
+  public init(
+    accelerometerData: @escaping (AnyHashable) -> AccelerometerData?,
+    attitudeReferenceFrame: @escaping (AnyHashable) -> CMAttitudeReferenceFrame,
+    availableAttitudeReferenceFrames: @escaping () -> CMAttitudeReferenceFrame,
+    create: @escaping (AnyHashable) -> Effect<Never, Never>,
+    destroy: @escaping (AnyHashable) -> Effect<Never, Never>,
+    deviceMotion: @escaping (AnyHashable) -> DeviceMotion?,
+    gyroData: @escaping (AnyHashable) -> GyroData?,
+    isAccelerometerActive: @escaping (AnyHashable) -> Bool,
+    isAccelerometerAvailable: @escaping (AnyHashable) -> Bool,
+    isDeviceMotionActive: @escaping (AnyHashable) -> Bool,
+    isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool,
+    isGyroActive: @escaping (AnyHashable) -> Bool,
+    isGyroAvailable: @escaping (AnyHashable) -> Bool,
+    isMagnetometerActive: @escaping (AnyHashable) -> Bool,
+    isMagnetometerAvailable: @escaping (AnyHashable) -> Bool,
+    magnetometerData: @escaping (AnyHashable) -> MagnetometerData?,
+    set: @escaping (AnyHashable, Properties) -> Effect<Never, Never>,
+    startAccelerometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
+      AccelerometerData, Error
+    >,
+    startDeviceMotionUpdates: @escaping (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) ->
+      Effect<DeviceMotion, Error>,
+    startGyroUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<GyroData, Error>,
+    startMagnetometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
+      MagnetometerData, Error
+    >,
+    stopAccelerometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
+    stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
+    stopGyroUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
+    stopMagnetometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never>
+  ) {
+    self.accelerometerData = accelerometerData
+    self.attitudeReferenceFrame = attitudeReferenceFrame
+    self.availableAttitudeReferenceFrames = availableAttitudeReferenceFrames
+    self.create = create
+    self.destroy = destroy
+    self.deviceMotion = deviceMotion
+    self.gyroData = gyroData
+    self.isAccelerometerActive = isAccelerometerActive
+    self.isAccelerometerAvailable = isAccelerometerAvailable
+    self.isDeviceMotionActive = isDeviceMotionActive
+    self.isDeviceMotionAvailable = isDeviceMotionAvailable
+    self.isGyroActive = isGyroActive
+    self.isGyroAvailable = isGyroAvailable
+    self.isMagnetometerActive = isMagnetometerActive
+    self.isMagnetometerAvailable = isMagnetometerAvailable
+    self.magnetometerData = magnetometerData
+    self.set = set
+    self.startAccelerometerUpdates = startAccelerometerUpdates
+    self.startDeviceMotionUpdates = startDeviceMotionUpdates
+    self.startGyroUpdates = startGyroUpdates
+    self.startMagnetometerUpdates = startMagnetometerUpdates
+    self.stopAccelerometerUpdates = stopAccelerometerUpdates
+    self.stopDeviceMotionUpdates = stopDeviceMotionUpdates
+    self.stopGyroUpdates = stopGyroUpdates
+    self.stopMagnetometerUpdates = stopMagnetometerUpdates
+  }
+
+  public struct Properties {
+    public var accelerometerUpdateInterval: TimeInterval?
+    public var deviceMotionUpdateInterval: TimeInterval?
+    public var gyroUpdateInterval: TimeInterval?
+    public var magnetometerUpdateInterval: TimeInterval?
+    public var showsDeviceMovementDisplay: Bool?
+
+    public init(
       accelerometerUpdateInterval: TimeInterval? = nil,
       deviceMotionUpdateInterval: TimeInterval? = nil,
       gyroUpdateInterval: TimeInterval? = nil,
       magnetometerUpdateInterval: TimeInterval? = nil,
       showsDeviceMovementDisplay: Bool? = nil
-    ) -> Effect<Never, Never> {
-      self.set(
-        id,
-        .init(
-          accelerometerUpdateInterval: accelerometerUpdateInterval,
-          deviceMotionUpdateInterval: deviceMotionUpdateInterval,
-          gyroUpdateInterval: gyroUpdateInterval,
-          magnetometerUpdateInterval: magnetometerUpdateInterval,
-          showsDeviceMovementDisplay: showsDeviceMovementDisplay
-        )
-      )
-    }
-
-    /// Starts accelerometer updates without a handler.
-    ///
-    /// Returns a long-living effect that emits accelerometer data each time the motion manager
-    /// receives a new value.
-    public func startAccelerometerUpdates(
-      id: AnyHashable,
-      to queue: OperationQueue = .main
-    ) -> Effect<AccelerometerData, Error> {
-      self.startAccelerometerUpdates(id, queue)
-    }
-
-    /// Starts device-motion updates without a block handler.
-    ///
-    /// Returns a long-living effect that emits device motion data each time the motion manager
-    /// receives a new value.
-    public func startDeviceMotionUpdates(
-      id: AnyHashable,
-      using referenceFrame: CMAttitudeReferenceFrame,
-      to queue: OperationQueue = .main
-    ) -> Effect<DeviceMotion, Error> {
-      self.startDeviceMotionUpdates(id, referenceFrame, queue)
-    }
-
-    /// Starts gyroscope updates without a handler.
-    ///
-    /// Returns a long-living effect that emits gyro data each time the motion manager receives a
-    /// new value.
-    public func startGyroUpdates(
-      id: AnyHashable,
-      to queue: OperationQueue = .main
-    ) -> Effect<GyroData, Error> {
-      self.startGyroUpdates(id, queue)
-    }
-
-    /// Starts magnetometer updates without a block handler.
-    ///
-    /// Returns a long-living effect that emits magnetometer data each time the motion manager
-    /// receives a new value.
-    public func startMagnetometerUpdates(
-      id: AnyHashable,
-      to queue: OperationQueue = .main
-    ) -> Effect<MagnetometerData, Error> {
-      self.startMagnetometerUpdates(id, queue)
-    }
-
-    /// Stops accelerometer updates.
-    public func stopAccelerometerUpdates(id: AnyHashable) -> Effect<Never, Never> {
-      self.stopAccelerometerUpdates(id)
-    }
-
-    /// Stops device-motion updates.
-    public func stopDeviceMotionUpdates(id: AnyHashable) -> Effect<Never, Never> {
-      self.stopDeviceMotionUpdates(id)
-    }
-
-    /// Stops gyroscope updates.
-    public func stopGyroUpdates(id: AnyHashable) -> Effect<Never, Never> {
-      self.stopGyroUpdates(id)
-    }
-
-    /// Stops magnetometer updates.
-    public func stopMagnetometerUpdates(id: AnyHashable) -> Effect<Never, Never> {
-      self.stopMagnetometerUpdates(id)
-    }
-
-    public init(
-      accelerometerData: @escaping (AnyHashable) -> AccelerometerData?,
-      attitudeReferenceFrame: @escaping (AnyHashable) -> CMAttitudeReferenceFrame,
-      availableAttitudeReferenceFrames: @escaping () -> CMAttitudeReferenceFrame,
-      create: @escaping (AnyHashable) -> Effect<Never, Never>,
-      destroy: @escaping (AnyHashable) -> Effect<Never, Never>,
-      deviceMotion: @escaping (AnyHashable) -> DeviceMotion?,
-      gyroData: @escaping (AnyHashable) -> GyroData?,
-      isAccelerometerActive: @escaping (AnyHashable) -> Bool,
-      isAccelerometerAvailable: @escaping (AnyHashable) -> Bool,
-      isDeviceMotionActive: @escaping (AnyHashable) -> Bool,
-      isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool,
-      isGyroActive: @escaping (AnyHashable) -> Bool,
-      isGyroAvailable: @escaping (AnyHashable) -> Bool,
-      isMagnetometerActive: @escaping (AnyHashable) -> Bool,
-      isMagnetometerAvailable: @escaping (AnyHashable) -> Bool,
-      magnetometerData: @escaping (AnyHashable) -> MagnetometerData?,
-      set: @escaping (AnyHashable, Properties) -> Effect<Never, Never>,
-      startAccelerometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
-        AccelerometerData, Error
-      >,
-      startDeviceMotionUpdates: @escaping (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) ->
-        Effect<DeviceMotion, Error>,
-      startGyroUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<GyroData, Error>,
-      startMagnetometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
-        MagnetometerData, Error
-      >,
-      stopAccelerometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
-      stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
-      stopGyroUpdates: @escaping (AnyHashable) -> Effect<Never, Never>,
-      stopMagnetometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never>
     ) {
-      self.accelerometerData = accelerometerData
-      self.attitudeReferenceFrame = attitudeReferenceFrame
-      self.availableAttitudeReferenceFrames = availableAttitudeReferenceFrames
-      self.create = create
-      self.destroy = destroy
-      self.deviceMotion = deviceMotion
-      self.gyroData = gyroData
-      self.isAccelerometerActive = isAccelerometerActive
-      self.isAccelerometerAvailable = isAccelerometerAvailable
-      self.isDeviceMotionActive = isDeviceMotionActive
-      self.isDeviceMotionAvailable = isDeviceMotionAvailable
-      self.isGyroActive = isGyroActive
-      self.isGyroAvailable = isGyroAvailable
-      self.isMagnetometerActive = isMagnetometerActive
-      self.isMagnetometerAvailable = isMagnetometerAvailable
-      self.magnetometerData = magnetometerData
-      self.set = set
-      self.startAccelerometerUpdates = startAccelerometerUpdates
-      self.startDeviceMotionUpdates = startDeviceMotionUpdates
-      self.startGyroUpdates = startGyroUpdates
-      self.startMagnetometerUpdates = startMagnetometerUpdates
-      self.stopAccelerometerUpdates = stopAccelerometerUpdates
-      self.stopDeviceMotionUpdates = stopDeviceMotionUpdates
-      self.stopGyroUpdates = stopGyroUpdates
-      self.stopMagnetometerUpdates = stopMagnetometerUpdates
+      self.accelerometerUpdateInterval = accelerometerUpdateInterval
+      self.deviceMotionUpdateInterval = deviceMotionUpdateInterval
+      self.gyroUpdateInterval = gyroUpdateInterval
+      self.magnetometerUpdateInterval = magnetometerUpdateInterval
+      self.showsDeviceMovementDisplay = showsDeviceMovementDisplay
     }
-
-    public struct Properties {
-      public var accelerometerUpdateInterval: TimeInterval?
-      public var deviceMotionUpdateInterval: TimeInterval?
-      public var gyroUpdateInterval: TimeInterval?
-      public var magnetometerUpdateInterval: TimeInterval?
-      public var showsDeviceMovementDisplay: Bool?
-
-      public init(
-        accelerometerUpdateInterval: TimeInterval? = nil,
-        deviceMotionUpdateInterval: TimeInterval? = nil,
-        gyroUpdateInterval: TimeInterval? = nil,
-        magnetometerUpdateInterval: TimeInterval? = nil,
-        showsDeviceMovementDisplay: Bool? = nil
-      ) {
-        self.accelerometerUpdateInterval = accelerometerUpdateInterval
-        self.deviceMotionUpdateInterval = deviceMotionUpdateInterval
-        self.gyroUpdateInterval = gyroUpdateInterval
-        self.magnetometerUpdateInterval = magnetometerUpdateInterval
-        self.showsDeviceMovementDisplay = showsDeviceMovementDisplay
-      }
-    }
-
-    var accelerometerData: (AnyHashable) -> AccelerometerData?
-    var attitudeReferenceFrame: (AnyHashable) -> CMAttitudeReferenceFrame
-    /// Returns a bitmask specifying the available attitude reference frames on the device.
-    var availableAttitudeReferenceFrames: () -> CMAttitudeReferenceFrame
-    var create: (AnyHashable) -> Effect<Never, Never>
-    var destroy: (AnyHashable) -> Effect<Never, Never>
-    var deviceMotion: (AnyHashable) -> DeviceMotion?
-    var gyroData: (AnyHashable) -> GyroData?
-    var isAccelerometerActive: (AnyHashable) -> Bool
-    var isAccelerometerAvailable: (AnyHashable) -> Bool
-    var isDeviceMotionActive: (AnyHashable) -> Bool
-    var isDeviceMotionAvailable: (AnyHashable) -> Bool
-    var isGyroActive: (AnyHashable) -> Bool
-    var isGyroAvailable: (AnyHashable) -> Bool
-    var isMagnetometerActive: (AnyHashable) -> Bool
-    var isMagnetometerAvailable: (AnyHashable) -> Bool
-    var magnetometerData: (AnyHashable) -> MagnetometerData?
-    var set: (AnyHashable, Properties) -> Effect<Never, Never>
-    var startAccelerometerUpdates: (AnyHashable, OperationQueue) -> Effect<AccelerometerData, Error>
-    var startDeviceMotionUpdates:
-      (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) -> Effect<DeviceMotion, Error>
-    var startGyroUpdates: (AnyHashable, OperationQueue) -> Effect<GyroData, Error>
-    var startMagnetometerUpdates: (AnyHashable, OperationQueue) -> Effect<MagnetometerData, Error>
-    var stopAccelerometerUpdates: (AnyHashable) -> Effect<Never, Never>
-    var stopDeviceMotionUpdates: (AnyHashable) -> Effect<Never, Never>
-    var stopGyroUpdates: (AnyHashable) -> Effect<Never, Never>
-    var stopMagnetometerUpdates: (AnyHashable) -> Effect<Never, Never>
   }
-#endif
+
+  var accelerometerData: (AnyHashable) -> AccelerometerData?
+  var attitudeReferenceFrame: (AnyHashable) -> CMAttitudeReferenceFrame
+  /// Returns a bitmask specifying the available attitude reference frames on the device.
+  var availableAttitudeReferenceFrames: () -> CMAttitudeReferenceFrame
+  var create: (AnyHashable) -> Effect<Never, Never>
+  var destroy: (AnyHashable) -> Effect<Never, Never>
+  var deviceMotion: (AnyHashable) -> DeviceMotion?
+  var gyroData: (AnyHashable) -> GyroData?
+  var isAccelerometerActive: (AnyHashable) -> Bool
+  var isAccelerometerAvailable: (AnyHashable) -> Bool
+  var isDeviceMotionActive: (AnyHashable) -> Bool
+  var isDeviceMotionAvailable: (AnyHashable) -> Bool
+  var isGyroActive: (AnyHashable) -> Bool
+  var isGyroAvailable: (AnyHashable) -> Bool
+  var isMagnetometerActive: (AnyHashable) -> Bool
+  var isMagnetometerAvailable: (AnyHashable) -> Bool
+  var magnetometerData: (AnyHashable) -> MagnetometerData?
+  var set: (AnyHashable, Properties) -> Effect<Never, Never>
+  var startAccelerometerUpdates: (AnyHashable, OperationQueue) -> Effect<AccelerometerData, Error>
+  var startDeviceMotionUpdates:
+    (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) -> Effect<DeviceMotion, Error>
+  var startGyroUpdates: (AnyHashable, OperationQueue) -> Effect<GyroData, Error>
+  var startMagnetometerUpdates: (AnyHashable, OperationQueue) -> Effect<MagnetometerData, Error>
+  var stopAccelerometerUpdates: (AnyHashable) -> Effect<Never, Never>
+  var stopDeviceMotionUpdates: (AnyHashable) -> Effect<Never, Never>
+  var stopGyroUpdates: (AnyHashable) -> Effect<Never, Never>
+  var stopMagnetometerUpdates: (AnyHashable) -> Effect<Never, Never>
+}

--- a/Sources/ComposableCoreMotion/MotionManager/MotionManagerLive.swift
+++ b/Sources/ComposableCoreMotion/MotionManager/MotionManagerLive.swift
@@ -1,264 +1,262 @@
-#if canImport(CoreMotion)
-  import Combine
-  import ComposableArchitecture
-  import CoreMotion
+import Combine
+import ComposableArchitecture
+import CoreMotion
 
-  @available(iOS 4, *)
-  @available(macCatalyst 13, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS 2, *)
-  extension MotionManager {
-    public static let live = MotionManager(
-      accelerometerData: { id in
-        requireMotionManager(id: id)?.accelerometerData.map(AccelerometerData.init)
-      },
-      attitudeReferenceFrame: { id in
-        requireMotionManager(id: id)?.attitudeReferenceFrame ?? .init()
-      },
-      availableAttitudeReferenceFrames: {
-        CMMotionManager.availableAttitudeReferenceFrames()
-      },
-      create: { id in
-        .fireAndForget {
-          if managers[id] != nil {
-            assertionFailure(
-              """
-              You are attempting to create a motion manager with the id \(id), but there is already \
-              a running manager with that id. This is considered a programmer error since you may \
-              be accidentally overwriting an existing manager without knowing.
+@available(iOS 4, *)
+@available(macCatalyst 13, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS 2, *)
+extension MotionManager {
+  public static let live = MotionManager(
+    accelerometerData: { id in
+      requireMotionManager(id: id)?.accelerometerData.map(AccelerometerData.init)
+    },
+    attitudeReferenceFrame: { id in
+      requireMotionManager(id: id)?.attitudeReferenceFrame ?? .init()
+    },
+    availableAttitudeReferenceFrames: {
+      CMMotionManager.availableAttitudeReferenceFrames()
+    },
+    create: { id in
+      .fireAndForget {
+        if managers[id] != nil {
+          assertionFailure(
+            """
+            You are attempting to create a motion manager with the id \(id), but there is already \
+            a running manager with that id. This is considered a programmer error since you may \
+            be accidentally overwriting an existing manager without knowing.
 
-              To fix you should either destroy the existing manager before creating a new one, or \
-              you should not try creating a new one before this one is destroyed.
-              """)
-          }
-          managers[id] = CMMotionManager()
+            To fix you should either destroy the existing manager before creating a new one, or \
+            you should not try creating a new one before this one is destroyed.
+            """)
         }
-      },
-      destroy: { id in
-        .fireAndForget { managers[id] = nil }
-      },
-      deviceMotion: { id in
-        requireMotionManager(id: id)?.deviceMotion.map(DeviceMotion.init)
-      },
-      gyroData: { id in
-        requireMotionManager(id: id)?.gyroData.map(GyroData.init)
-      },
-      isAccelerometerActive: { id in
-        requireMotionManager(id: id)?.isAccelerometerActive ?? false
-      },
-      isAccelerometerAvailable: { id in
-        requireMotionManager(id: id)?.isAccelerometerAvailable ?? false
-      },
-      isDeviceMotionActive: { id in
-        requireMotionManager(id: id)?.isDeviceMotionActive ?? false
-      },
-      isDeviceMotionAvailable: { id in
-        requireMotionManager(id: id)?.isDeviceMotionAvailable ?? false
-      },
-      isGyroActive: { id in
-        requireMotionManager(id: id)?.isGyroActive ?? false
-      },
-      isGyroAvailable: { id in
-        requireMotionManager(id: id)?.isGyroAvailable ?? false
-      },
-      isMagnetometerActive: { id in
-        requireMotionManager(id: id)?.isDeviceMotionActive ?? false
-      },
-      isMagnetometerAvailable: { id in
-        requireMotionManager(id: id)?.isMagnetometerAvailable ?? false
-      },
-      magnetometerData: { id in
-        requireMotionManager(id: id)?.magnetometerData.map(MagnetometerData.init)
-      },
-      set: { id, properties in
-        .fireAndForget {
-          guard let manager = requireMotionManager(id: id)
-          else {
-            return
-          }
-
-          if let accelerometerUpdateInterval = properties.accelerometerUpdateInterval {
-            manager.accelerometerUpdateInterval = accelerometerUpdateInterval
-          }
-          if let deviceMotionUpdateInterval = properties.deviceMotionUpdateInterval {
-            manager.deviceMotionUpdateInterval = deviceMotionUpdateInterval
-          }
-          if let gyroUpdateInterval = properties.gyroUpdateInterval {
-            manager.gyroUpdateInterval = gyroUpdateInterval
-          }
-          if let magnetometerUpdateInterval = properties.magnetometerUpdateInterval {
-            manager.magnetometerUpdateInterval = magnetometerUpdateInterval
-          }
-          if let showsDeviceMovementDisplay = properties.showsDeviceMovementDisplay {
-            manager.showsDeviceMovementDisplay = showsDeviceMovementDisplay
-          }
-        }
-      },
-      startAccelerometerUpdates: { id, queue in
-        return Effect.run { subscriber in
-          guard let manager = requireMotionManager(id: id)
-          else {
-            return AnyCancellable {}
-          }
-          guard accelerometerUpdatesSubscribers[id] == nil
-          else { return AnyCancellable {} }
-
-          accelerometerUpdatesSubscribers[id] = subscriber
-          manager.startAccelerometerUpdates(to: queue) { data, error in
-            if let data = data {
-              subscriber.send(.init(data))
-            } else if let error = error {
-              subscriber.send(completion: .failure(error))
-            }
-          }
-          return AnyCancellable {
-            manager.stopAccelerometerUpdates()
-          }
-        }
-      },
-      startDeviceMotionUpdates: { id, frame, queue in
-        return Effect.run { subscriber in
-          guard let manager = requireMotionManager(id: id)
-          else {
-            return AnyCancellable {}
-          }
-          guard deviceMotionUpdatesSubscribers[id] == nil
-          else { return AnyCancellable {} }
-
-          deviceMotionUpdatesSubscribers[id] = subscriber
-          manager.startDeviceMotionUpdates(using: frame, to: queue) { data, error in
-            if let data = data {
-              subscriber.send(.init(data))
-            } else if let error = error {
-              subscriber.send(completion: .failure(error))
-            }
-          }
-          return AnyCancellable {
-            manager.stopDeviceMotionUpdates()
-          }
-        }
-      },
-      startGyroUpdates: { id, queue in
-        return Effect.run { subscriber in
-          guard let manager = requireMotionManager(id: id)
-          else {
-            return AnyCancellable {}
-          }
-          guard deviceGyroUpdatesSubscribers[id] == nil
-          else { return AnyCancellable {} }
-
-          deviceGyroUpdatesSubscribers[id] = subscriber
-          manager.startGyroUpdates(to: queue) { data, error in
-            if let data = data {
-              subscriber.send(.init(data))
-            } else if let error = error {
-              subscriber.send(completion: .failure(error))
-            }
-          }
-          return AnyCancellable {
-            manager.stopGyroUpdates()
-          }
-        }
-      },
-      startMagnetometerUpdates: { id, queue in
-        return Effect.run { subscriber in
-          guard let manager = managers[id]
-          else {
-            couldNotFindMotionManager(id: id)
-            return AnyCancellable {}
-          }
-          guard deviceMagnetometerUpdatesSubscribers[id] == nil
-          else { return AnyCancellable {} }
-
-          deviceMagnetometerUpdatesSubscribers[id] = subscriber
-          manager.startMagnetometerUpdates(to: queue) { data, error in
-            if let data = data {
-              subscriber.send(.init(data))
-            } else if let error = error {
-              subscriber.send(completion: .failure(error))
-            }
-          }
-          return AnyCancellable {
-            manager.stopMagnetometerUpdates()
-          }
-        }
-      },
-      stopAccelerometerUpdates: { id in
-        .fireAndForget {
-          guard let manager = managers[id]
-          else {
-            couldNotFindMotionManager(id: id)
-            return
-          }
-          manager.stopAccelerometerUpdates()
-          accelerometerUpdatesSubscribers[id]?.send(completion: .finished)
-          accelerometerUpdatesSubscribers[id] = nil
-        }
-      },
-      stopDeviceMotionUpdates: { id in
-        .fireAndForget {
-          guard let manager = managers[id]
-          else {
-            couldNotFindMotionManager(id: id)
-            return
-          }
-          manager.stopDeviceMotionUpdates()
-          deviceMotionUpdatesSubscribers[id]?.send(completion: .finished)
-          deviceMotionUpdatesSubscribers[id] = nil
-        }
-      },
-      stopGyroUpdates: { id in
-        .fireAndForget {
-          guard let manager = managers[id]
-          else {
-            couldNotFindMotionManager(id: id)
-            return
-          }
-          manager.stopGyroUpdates()
-          deviceGyroUpdatesSubscribers[id]?.send(completion: .finished)
-          deviceGyroUpdatesSubscribers[id] = nil
-        }
-      },
-      stopMagnetometerUpdates: { id in
-        .fireAndForget {
-          guard let manager = managers[id]
-          else {
-            couldNotFindMotionManager(id: id)
-            return
-          }
-          manager.stopMagnetometerUpdates()
-          deviceMagnetometerUpdatesSubscribers[id]?.send(completion: .finished)
-          deviceMagnetometerUpdatesSubscribers[id] = nil
-        }
-      })
-
-    private static var managers: [AnyHashable: CMMotionManager] = [:]
-
-    private static func requireMotionManager(id: AnyHashable) -> CMMotionManager? {
-      if managers[id] == nil {
-        couldNotFindMotionManager(id: id)
+        managers[id] = CMMotionManager()
       }
-      return managers[id]
+    },
+    destroy: { id in
+      .fireAndForget { managers[id] = nil }
+    },
+    deviceMotion: { id in
+      requireMotionManager(id: id)?.deviceMotion.map(DeviceMotion.init)
+    },
+    gyroData: { id in
+      requireMotionManager(id: id)?.gyroData.map(GyroData.init)
+    },
+    isAccelerometerActive: { id in
+      requireMotionManager(id: id)?.isAccelerometerActive ?? false
+    },
+    isAccelerometerAvailable: { id in
+      requireMotionManager(id: id)?.isAccelerometerAvailable ?? false
+    },
+    isDeviceMotionActive: { id in
+      requireMotionManager(id: id)?.isDeviceMotionActive ?? false
+    },
+    isDeviceMotionAvailable: { id in
+      requireMotionManager(id: id)?.isDeviceMotionAvailable ?? false
+    },
+    isGyroActive: { id in
+      requireMotionManager(id: id)?.isGyroActive ?? false
+    },
+    isGyroAvailable: { id in
+      requireMotionManager(id: id)?.isGyroAvailable ?? false
+    },
+    isMagnetometerActive: { id in
+      requireMotionManager(id: id)?.isDeviceMotionActive ?? false
+    },
+    isMagnetometerAvailable: { id in
+      requireMotionManager(id: id)?.isMagnetometerAvailable ?? false
+    },
+    magnetometerData: { id in
+      requireMotionManager(id: id)?.magnetometerData.map(MagnetometerData.init)
+    },
+    set: { id, properties in
+      .fireAndForget {
+        guard let manager = requireMotionManager(id: id)
+        else {
+          return
+        }
+
+        if let accelerometerUpdateInterval = properties.accelerometerUpdateInterval {
+          manager.accelerometerUpdateInterval = accelerometerUpdateInterval
+        }
+        if let deviceMotionUpdateInterval = properties.deviceMotionUpdateInterval {
+          manager.deviceMotionUpdateInterval = deviceMotionUpdateInterval
+        }
+        if let gyroUpdateInterval = properties.gyroUpdateInterval {
+          manager.gyroUpdateInterval = gyroUpdateInterval
+        }
+        if let magnetometerUpdateInterval = properties.magnetometerUpdateInterval {
+          manager.magnetometerUpdateInterval = magnetometerUpdateInterval
+        }
+        if let showsDeviceMovementDisplay = properties.showsDeviceMovementDisplay {
+          manager.showsDeviceMovementDisplay = showsDeviceMovementDisplay
+        }
+      }
+    },
+    startAccelerometerUpdates: { id, queue in
+      return Effect.run { subscriber in
+        guard let manager = requireMotionManager(id: id)
+        else {
+          return AnyCancellable {}
+        }
+        guard accelerometerUpdatesSubscribers[id] == nil
+        else { return AnyCancellable {} }
+
+        accelerometerUpdatesSubscribers[id] = subscriber
+        manager.startAccelerometerUpdates(to: queue) { data, error in
+          if let data = data {
+            subscriber.send(.init(data))
+          } else if let error = error {
+            subscriber.send(completion: .failure(error))
+          }
+        }
+        return AnyCancellable {
+          manager.stopAccelerometerUpdates()
+        }
+      }
+    },
+    startDeviceMotionUpdates: { id, frame, queue in
+      return Effect.run { subscriber in
+        guard let manager = requireMotionManager(id: id)
+        else {
+          return AnyCancellable {}
+        }
+        guard deviceMotionUpdatesSubscribers[id] == nil
+        else { return AnyCancellable {} }
+
+        deviceMotionUpdatesSubscribers[id] = subscriber
+        manager.startDeviceMotionUpdates(using: frame, to: queue) { data, error in
+          if let data = data {
+            subscriber.send(.init(data))
+          } else if let error = error {
+            subscriber.send(completion: .failure(error))
+          }
+        }
+        return AnyCancellable {
+          manager.stopDeviceMotionUpdates()
+        }
+      }
+    },
+    startGyroUpdates: { id, queue in
+      return Effect.run { subscriber in
+        guard let manager = requireMotionManager(id: id)
+        else {
+          return AnyCancellable {}
+        }
+        guard deviceGyroUpdatesSubscribers[id] == nil
+        else { return AnyCancellable {} }
+
+        deviceGyroUpdatesSubscribers[id] = subscriber
+        manager.startGyroUpdates(to: queue) { data, error in
+          if let data = data {
+            subscriber.send(.init(data))
+          } else if let error = error {
+            subscriber.send(completion: .failure(error))
+          }
+        }
+        return AnyCancellable {
+          manager.stopGyroUpdates()
+        }
+      }
+    },
+    startMagnetometerUpdates: { id, queue in
+      return Effect.run { subscriber in
+        guard let manager = managers[id]
+        else {
+          couldNotFindMotionManager(id: id)
+          return AnyCancellable {}
+        }
+        guard deviceMagnetometerUpdatesSubscribers[id] == nil
+        else { return AnyCancellable {} }
+
+        deviceMagnetometerUpdatesSubscribers[id] = subscriber
+        manager.startMagnetometerUpdates(to: queue) { data, error in
+          if let data = data {
+            subscriber.send(.init(data))
+          } else if let error = error {
+            subscriber.send(completion: .failure(error))
+          }
+        }
+        return AnyCancellable {
+          manager.stopMagnetometerUpdates()
+        }
+      }
+    },
+    stopAccelerometerUpdates: { id in
+      .fireAndForget {
+        guard let manager = managers[id]
+        else {
+          couldNotFindMotionManager(id: id)
+          return
+        }
+        manager.stopAccelerometerUpdates()
+        accelerometerUpdatesSubscribers[id]?.send(completion: .finished)
+        accelerometerUpdatesSubscribers[id] = nil
+      }
+    },
+    stopDeviceMotionUpdates: { id in
+      .fireAndForget {
+        guard let manager = managers[id]
+        else {
+          couldNotFindMotionManager(id: id)
+          return
+        }
+        manager.stopDeviceMotionUpdates()
+        deviceMotionUpdatesSubscribers[id]?.send(completion: .finished)
+        deviceMotionUpdatesSubscribers[id] = nil
+      }
+    },
+    stopGyroUpdates: { id in
+      .fireAndForget {
+        guard let manager = managers[id]
+        else {
+          couldNotFindMotionManager(id: id)
+          return
+        }
+        manager.stopGyroUpdates()
+        deviceGyroUpdatesSubscribers[id]?.send(completion: .finished)
+        deviceGyroUpdatesSubscribers[id] = nil
+      }
+    },
+    stopMagnetometerUpdates: { id in
+      .fireAndForget {
+        guard let manager = managers[id]
+        else {
+          couldNotFindMotionManager(id: id)
+          return
+        }
+        manager.stopMagnetometerUpdates()
+        deviceMagnetometerUpdatesSubscribers[id]?.send(completion: .finished)
+        deviceMagnetometerUpdatesSubscribers[id] = nil
+      }
+    })
+
+  private static var managers: [AnyHashable: CMMotionManager] = [:]
+
+  private static func requireMotionManager(id: AnyHashable) -> CMMotionManager? {
+    if managers[id] == nil {
+      couldNotFindMotionManager(id: id)
     }
+    return managers[id]
   }
+}
 
-  private var accelerometerUpdatesSubscribers:
-    [AnyHashable: Effect<AccelerometerData, Error>.Subscriber] = [:]
-  private var deviceMotionUpdatesSubscribers:
-    [AnyHashable: Effect<DeviceMotion, Error>.Subscriber] =
-      [:]
-  private var deviceGyroUpdatesSubscribers: [AnyHashable: Effect<GyroData, Error>.Subscriber] = [:]
-  private var deviceMagnetometerUpdatesSubscribers:
-    [AnyHashable: Effect<MagnetometerData, Error>.Subscriber] = [:]
+private var accelerometerUpdatesSubscribers:
+  [AnyHashable: Effect<AccelerometerData, Error>.Subscriber] = [:]
+private var deviceMotionUpdatesSubscribers:
+  [AnyHashable: Effect<DeviceMotion, Error>.Subscriber] =
+    [:]
+private var deviceGyroUpdatesSubscribers: [AnyHashable: Effect<GyroData, Error>.Subscriber] = [:]
+private var deviceMagnetometerUpdatesSubscribers:
+  [AnyHashable: Effect<MagnetometerData, Error>.Subscriber] = [:]
 
-  private func couldNotFindMotionManager(id: Any) {
-    assertionFailure(
-      """
-      A motion manager could not be found with the id \(id). This is considered a programmer error. \
-      You should not invoke methods on a motion manager before it has been created or after it \
-      has been destroyed. Refactor your code to make sure there is a motion manager created by the \
-      time you invoke this endpoint.
-      """)
-  }
-#endif
+private func couldNotFindMotionManager(id: Any) {
+  assertionFailure(
+    """
+    A motion manager could not be found with the id \(id). This is considered a programmer error. \
+    You should not invoke methods on a motion manager before it has been created or after it \
+    has been destroyed. Refactor your code to make sure there is a motion manager created by the \
+    time you invoke this endpoint.
+    """)
+}

--- a/Sources/ComposableCoreMotion/MotionManager/MotionManagerMock.swift
+++ b/Sources/ComposableCoreMotion/MotionManager/MotionManagerMock.swift
@@ -1,105 +1,103 @@
-#if canImport(CoreMotion)
-  import ComposableArchitecture
+import ComposableArchitecture
 
-  @available(iOS 4.0, *)
-  @available(macCatalyst 13.0, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS 2.0, *)
-  extension MotionManager {
-    public static func unimplemented(
-      accelerometerData: @escaping (AnyHashable) -> AccelerometerData? = { _ in
-        _unimplemented("accelerometerData")
-      },
-      attitudeReferenceFrame: @escaping (AnyHashable) -> CMAttitudeReferenceFrame = { _ in
-        _unimplemented("attitudeReferenceFrame")
-      },
-      availableAttitudeReferenceFrames: @escaping () -> CMAttitudeReferenceFrame = {
-        _unimplemented("availableAttitudeReferenceFrames")
-      },
-      create: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("create") },
-      destroy: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("destroy") },
-      deviceMotion: @escaping (AnyHashable) -> DeviceMotion? = { _ in _unimplemented("deviceMotion")
-      },
-      gyroData: @escaping (AnyHashable) -> GyroData? = { _ in _unimplemented("gyroData") },
-      isAccelerometerActive: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isAccelerometerActive")
-      },
-      isAccelerometerAvailable: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isAccelerometerAvailable")
-      },
-      isDeviceMotionActive: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isDeviceMotionActive")
-      },
-      isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isDeviceMotionAvailable")
-      },
-      isGyroActive: @escaping (AnyHashable) -> Bool = { _ in _unimplemented("isGyroActive") },
-      isGyroAvailable: @escaping (AnyHashable) -> Bool = { _ in _unimplemented("isGyroAvailable") },
-      isMagnetometerActive: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isMagnetometerActive")
-      },
-      isMagnetometerAvailable: @escaping (AnyHashable) -> Bool = { _ in
-        _unimplemented("isMagnetometerAvailable")
-      },
-      magnetometerData: @escaping (AnyHashable) -> MagnetometerData? = { _ in
-        _unimplemented("magnetometerData")
-      },
-      set: @escaping (AnyHashable, MotionManager.Properties) -> Effect<Never, Never> = { _, _ in
-        _unimplemented("set")
-      },
-      startAccelerometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
-        AccelerometerData, Error
-      > = { _, _ in _unimplemented("startAccelerometerUpdates") },
-      startDeviceMotionUpdates: @escaping (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) ->
-        Effect<DeviceMotion, Error> = { _, _, _ in _unimplemented("startDeviceMotionUpdates") },
-      startGyroUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<GyroData, Error> = {
-        _, _ in
-        _unimplemented("startGyroUpdates")
-      },
-      startMagnetometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
-        MagnetometerData, Error
-      > = { _, _ in _unimplemented("startMagnetometerUpdates") },
-      stopAccelerometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
-        _unimplemented("stopAccelerometerUpdates")
-      },
-      stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
-        _unimplemented("stopDeviceMotionUpdates")
-      },
-      stopGyroUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
-        _unimplemented("stopGyroUpdates")
-      },
-      stopMagnetometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
-        _unimplemented("stopMagnetometerUpdates")
-      }
-    ) -> MotionManager {
-      Self(
-        accelerometerData: accelerometerData,
-        attitudeReferenceFrame: attitudeReferenceFrame,
-        availableAttitudeReferenceFrames: availableAttitudeReferenceFrames,
-        create: create,
-        destroy: destroy,
-        deviceMotion: deviceMotion,
-        gyroData: gyroData,
-        isAccelerometerActive: isAccelerometerActive,
-        isAccelerometerAvailable: isAccelerometerAvailable,
-        isDeviceMotionActive: isDeviceMotionActive,
-        isDeviceMotionAvailable: isDeviceMotionAvailable,
-        isGyroActive: isGyroActive,
-        isGyroAvailable: isGyroAvailable,
-        isMagnetometerActive: isMagnetometerActive,
-        isMagnetometerAvailable: isMagnetometerAvailable,
-        magnetometerData: magnetometerData,
-        set: set,
-        startAccelerometerUpdates: startAccelerometerUpdates,
-        startDeviceMotionUpdates: startDeviceMotionUpdates,
-        startGyroUpdates: startGyroUpdates,
-        startMagnetometerUpdates: startMagnetometerUpdates,
-        stopAccelerometerUpdates: stopAccelerometerUpdates,
-        stopDeviceMotionUpdates: stopDeviceMotionUpdates,
-        stopGyroUpdates: stopGyroUpdates,
-        stopMagnetometerUpdates: stopMagnetometerUpdates
-      )
+@available(iOS 4.0, *)
+@available(macCatalyst 13.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS 2.0, *)
+extension MotionManager {
+  public static func unimplemented(
+    accelerometerData: @escaping (AnyHashable) -> AccelerometerData? = { _ in
+      _unimplemented("accelerometerData")
+    },
+    attitudeReferenceFrame: @escaping (AnyHashable) -> CMAttitudeReferenceFrame = { _ in
+      _unimplemented("attitudeReferenceFrame")
+    },
+    availableAttitudeReferenceFrames: @escaping () -> CMAttitudeReferenceFrame = {
+      _unimplemented("availableAttitudeReferenceFrames")
+    },
+    create: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("create") },
+    destroy: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("destroy") },
+    deviceMotion: @escaping (AnyHashable) -> DeviceMotion? = { _ in _unimplemented("deviceMotion")
+    },
+    gyroData: @escaping (AnyHashable) -> GyroData? = { _ in _unimplemented("gyroData") },
+    isAccelerometerActive: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isAccelerometerActive")
+    },
+    isAccelerometerAvailable: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isAccelerometerAvailable")
+    },
+    isDeviceMotionActive: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isDeviceMotionActive")
+    },
+    isDeviceMotionAvailable: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isDeviceMotionAvailable")
+    },
+    isGyroActive: @escaping (AnyHashable) -> Bool = { _ in _unimplemented("isGyroActive") },
+    isGyroAvailable: @escaping (AnyHashable) -> Bool = { _ in _unimplemented("isGyroAvailable") },
+    isMagnetometerActive: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isMagnetometerActive")
+    },
+    isMagnetometerAvailable: @escaping (AnyHashable) -> Bool = { _ in
+      _unimplemented("isMagnetometerAvailable")
+    },
+    magnetometerData: @escaping (AnyHashable) -> MagnetometerData? = { _ in
+      _unimplemented("magnetometerData")
+    },
+    set: @escaping (AnyHashable, MotionManager.Properties) -> Effect<Never, Never> = { _, _ in
+      _unimplemented("set")
+    },
+    startAccelerometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
+      AccelerometerData, Error
+    > = { _, _ in _unimplemented("startAccelerometerUpdates") },
+    startDeviceMotionUpdates: @escaping (AnyHashable, CMAttitudeReferenceFrame, OperationQueue) ->
+      Effect<DeviceMotion, Error> = { _, _, _ in _unimplemented("startDeviceMotionUpdates") },
+    startGyroUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<GyroData, Error> = {
+      _, _ in
+      _unimplemented("startGyroUpdates")
+    },
+    startMagnetometerUpdates: @escaping (AnyHashable, OperationQueue) -> Effect<
+      MagnetometerData, Error
+    > = { _, _ in _unimplemented("startMagnetometerUpdates") },
+    stopAccelerometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      _unimplemented("stopAccelerometerUpdates")
+    },
+    stopDeviceMotionUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      _unimplemented("stopDeviceMotionUpdates")
+    },
+    stopGyroUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      _unimplemented("stopGyroUpdates")
+    },
+    stopMagnetometerUpdates: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      _unimplemented("stopMagnetometerUpdates")
     }
+  ) -> MotionManager {
+    Self(
+      accelerometerData: accelerometerData,
+      attitudeReferenceFrame: attitudeReferenceFrame,
+      availableAttitudeReferenceFrames: availableAttitudeReferenceFrames,
+      create: create,
+      destroy: destroy,
+      deviceMotion: deviceMotion,
+      gyroData: gyroData,
+      isAccelerometerActive: isAccelerometerActive,
+      isAccelerometerAvailable: isAccelerometerAvailable,
+      isDeviceMotionActive: isDeviceMotionActive,
+      isDeviceMotionAvailable: isDeviceMotionAvailable,
+      isGyroActive: isGyroActive,
+      isGyroAvailable: isGyroAvailable,
+      isMagnetometerActive: isMagnetometerActive,
+      isMagnetometerAvailable: isMagnetometerAvailable,
+      magnetometerData: magnetometerData,
+      set: set,
+      startAccelerometerUpdates: startAccelerometerUpdates,
+      startDeviceMotionUpdates: startDeviceMotionUpdates,
+      startGyroUpdates: startGyroUpdates,
+      startMagnetometerUpdates: startMagnetometerUpdates,
+      stopAccelerometerUpdates: stopAccelerometerUpdates,
+      stopDeviceMotionUpdates: stopDeviceMotionUpdates,
+      stopGyroUpdates: stopGyroUpdates,
+      stopMagnetometerUpdates: stopMagnetometerUpdates
+    )
   }
-#endif
+}

--- a/Tests/ComposableCoreMotionTests/ComposableCoreMotionTests.swift
+++ b/Tests/ComposableCoreMotionTests/ComposableCoreMotionTests.swift
@@ -1,52 +1,50 @@
-#if canImport(CoreMotion)
-  import XCTest
+import XCTest
 
-  @testable import ComposableCoreMotion
+@testable import ComposableCoreMotion
 
-  class ComposableCoreMotionTests: XCTestCase {
-    func testQuaternionInverse() {
-      let q = CMQuaternion(x: 1, y: 2, z: 3, w: 4)
-      let inv = q.inverse
-      let result = q.multiplied(by: inv)
+class ComposableCoreMotionTests: XCTestCase {
+  func testQuaternionInverse() {
+    let q = CMQuaternion(x: 1, y: 2, z: 3, w: 4)
+    let inv = q.inverse
+    let result = q.multiplied(by: inv)
 
-      XCTAssertEqual(result.x, 0)
-      XCTAssertEqual(result.y, 0)
-      XCTAssertEqual(result.z, 0)
-      XCTAssertEqual(result.w, 1)
-    }
-
-    func testQuaternionMultiplication() {
-      let q1 = CMQuaternion(x: 1, y: 2, z: 3, w: 4)
-      let q2 = CMQuaternion(x: -4, y: 3, z: -2, w: 1)
-      let result = q1.multiplied(by: q2)
-
-      XCTAssertEqual(result.x, -28)
-      XCTAssertEqual(result.y, 4)
-      XCTAssertEqual(result.z, 6)
-      XCTAssertEqual(result.w, 8)
-    }
-
-    func testRollPitchYaw() {
-      let q1 = Attitude(quaternion: .init(x: 1, y: 0, z: 0, w: 0))
-      let q2 = Attitude(quaternion: .init(x: 0, y: 1, z: 0, w: 0))
-      let q3 = Attitude(quaternion: .init(x: 0, y: 0, z: 1, w: 0))
-      let q4 = Attitude(quaternion: .init(x: 0, y: 0, z: 0, w: 1))
-
-      XCTAssertEqual(q1.roll, Double.pi)
-      XCTAssertEqual(q1.pitch, 0)
-      XCTAssertEqual(q1.yaw, 0)
-
-      XCTAssertEqual(q2.roll, Double.pi)
-      XCTAssertEqual(q2.pitch, 0)
-      XCTAssertEqual(q2.yaw, Double.pi)
-
-      XCTAssertEqual(q3.roll, 0)
-      XCTAssertEqual(q3.pitch, 0)
-      XCTAssertEqual(q3.yaw, Double.pi)
-
-      XCTAssertEqual(q4.roll, 0)
-      XCTAssertEqual(q4.pitch, 0)
-      XCTAssertEqual(q4.yaw, 0)
-    }
+    XCTAssertEqual(result.x, 0)
+    XCTAssertEqual(result.y, 0)
+    XCTAssertEqual(result.z, 0)
+    XCTAssertEqual(result.w, 1)
   }
-#endif
+
+  func testQuaternionMultiplication() {
+    let q1 = CMQuaternion(x: 1, y: 2, z: 3, w: 4)
+    let q2 = CMQuaternion(x: -4, y: 3, z: -2, w: 1)
+    let result = q1.multiplied(by: q2)
+
+    XCTAssertEqual(result.x, -28)
+    XCTAssertEqual(result.y, 4)
+    XCTAssertEqual(result.z, 6)
+    XCTAssertEqual(result.w, 8)
+  }
+
+  func testRollPitchYaw() {
+    let q1 = Attitude(quaternion: .init(x: 1, y: 0, z: 0, w: 0))
+    let q2 = Attitude(quaternion: .init(x: 0, y: 1, z: 0, w: 0))
+    let q3 = Attitude(quaternion: .init(x: 0, y: 0, z: 1, w: 0))
+    let q4 = Attitude(quaternion: .init(x: 0, y: 0, z: 0, w: 1))
+
+    XCTAssertEqual(q1.roll, Double.pi)
+    XCTAssertEqual(q1.pitch, 0)
+    XCTAssertEqual(q1.yaw, 0)
+
+    XCTAssertEqual(q2.roll, Double.pi)
+    XCTAssertEqual(q2.pitch, 0)
+    XCTAssertEqual(q2.yaw, Double.pi)
+
+    XCTAssertEqual(q3.roll, 0)
+    XCTAssertEqual(q3.pitch, 0)
+    XCTAssertEqual(q3.yaw, Double.pi)
+
+    XCTAssertEqual(q4.roll, 0)
+    XCTAssertEqual(q4.pitch, 0)
+    XCTAssertEqual(q4.yaw, 0)
+  }
+}


### PR DESCRIPTION
I dunno why we did this, but we've undone it in combine-schedulers, so let's do the same here. Should also help make future PRs easier to read than combining with this work.